### PR TITLE
Update README.md "SSHTUNNEL_TUNNEL_CONFIG" env variable instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ heroku buildpacks:set heroku/nodejs
 The buildpack creates an ssh tunnel on the basis of the environment variables configured for Heroku:
 
 - ``SSHTUNNEL_PRIVATE_KEY``: Private key for connecting to the tunnel host
-- ``SSHTUNNEL_TUNNEL_CONFIG``: Tunnel configuration (openssh -L syntax without the ``LOCAL_HOST``) ``[LOCAL PORT]:[REMOTE_HOST]:[REMOTE_PORT]``
+- ``SSHTUNNEL_TUNNEL_CONFIG``: Tunnel configuration (openssh -L syntax without the ``LOCAL_HOST``) ``[LOCAL PORT] [REMOTE_HOST]:[REMOTE_PORT]``
 - ``SSHTUNNEL_REMOTE_USER``: Username for connecting to the tunnel server
 - ``SSHTUNNEL_REMOTE_HOST``: The tunnel server hostname
 - ``SSHTUNNEL_REMOTE_PORT``: (optional) Port for connecting the tunnel server. Default is 22.


### PR DESCRIPTION
Corrected the SSH_TUNNEL_CONFIG part env variable instrucitons. Since the script creates/edits SSH config file, the [LOCAL_PORT]:[REMOTE_HOST]:[REMOTE_PORT] syntax is wrong. "LocalForward" directive uses [LOCAL_PORT] [REMOTE_HOST]:[REMOTE_PORT] syntax with a space.